### PR TITLE
rename pyHARM -> pyharm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
 # 'dev' branch NOTE:
-This branch is significantly changed from previous versions of pyHARM.  Therefore, some scripts and even outer portions of the library are temporarily broken until imports and interface changes are updated.  The core features described in the new README sections below should work, as should anything around `movie.py`, i.e. plotting of KHARMA dumps and everything to do with coordinates.  I've tried to update the documentation as I go, but pieces, especially in the open documentation pages, are several versions behind still.
+This branch is significantly changed from previous versions of pyharm.  Therefore, some scripts and even outer portions of the library are temporarily broken until imports and interface changes are updated.  The core features described in the new README sections below should work, as should anything around `movie.py`, i.e. plotting of KHARMA dumps and everything to do with coordinates.  I've tried to update the documentation as I go, but pieces, especially in the open documentation pages, are several versions behind still.
 
-Once everything is in fairly complete working order, the plan is to upload pyHARM to pyPI to have a single working base that's easy to install into different environments.  If you'd like to write your own scripts around KHARMA dumps, the file `pyHARM/io/kharma.py`, specifically `read_var`, is a good place to start.  For a basic reader, you can safely ignore index operations related to ghost zones and slicing, but note the matrix transformations required to read KHARMA "meshblocks" into a single whole "mesh."
+Once everything is in fairly complete working order, the plan is to upload pyharm to pyPI to have a single working base that's easy to install into different environments.  If you'd like to write your own scripts around KHARMA dumps, the file `pyharm/io/kharma.py`, specifically `read_var`, is a good place to start.  For a basic reader, you can safely ignore index operations related to ghost zones and slicing, but note the matrix transformations required to read KHARMA "meshblocks" into a single whole "mesh."
 
-# pyHARM
+# pyharm
 Python tools for HARM analysis
 
-`pyHARM` is a set of Python functions for analyzing and plotting the output of General-Relativistic Magnetohydrodynamic (GRMHD) simulations.  It includes functions for obtaining a long list of different variables of interest (pressures, temperatures, stress-energy tensor, synchrotron emissivity) based on local fluid state.  It additionally includes reductions for performing surface and volume integrals of various types, and plotting tools, as well as MPI-accelerated scripts for producing movies and time-summed or -averaged reductions over large-scale simulations.
+`pyharm` is a set of Python functions for analyzing and plotting the output of General-Relativistic Magnetohydrodynamic (GRMHD) simulations.  It includes functions for obtaining a long list of different variables of interest (pressures, temperatures, stress-energy tensor, synchrotron emissivity) based on local fluid state.  It additionally includes reductions for performing surface and volume integrals of various types, and plotting tools, as well as MPI-accelerated scripts for producing movies and time-summed or -averaged reductions over large-scale simulations.
 
-`pyHARM` primarily supports simulations based on the HARM scheme (Gammie et al. 2003) -- [KHARMA](https://github.com/AFD-Illinois/kharma), [iharm3d](https://github.com/AFD-Illinois/iharm3d), and [ebhlight](https://github.com/AFD-Illinois/ebhlight).  It includes Python re-implementations of core parts of the scheme, useful for deriving everything about the simulation not directly present in output files.  It includes limited support for several other codes, either directly or after translation with [EHT-babel](https://github.com/AFD-Illinois/EHT-babel/).
+`pyharm` primarily supports simulations based on the HARM scheme (Gammie et al. 2003) -- [KHARMA](https://github.com/AFD-Illinois/kharma), [iharm3d](https://github.com/AFD-Illinois/iharm3d), and [ebhlight](https://github.com/AFD-Illinois/ebhlight).  It includes Python re-implementations of core parts of the scheme, useful for deriving everything about the simulation not directly present in output files.  It includes limited support for several other codes, either directly or after translation with [EHT-babel](https://github.com/AFD-Illinois/EHT-babel/).
 
-The core of pyHARM is the `FluidDump` object, which behaves similar to a Python dictionary of `numpy` arrays, but calculates its members on the fly by reading the original file and performing operations only as necessary ("lazy" evaluation).  `FluidDump` objects can be sliced similarly to `numpy` arrays, and subsequent file reads and calculations will be done over only the sliced portion.
+The core of pyharm is the `FluidDump` object, which behaves similar to a Python dictionary of `numpy` arrays, but calculates its members on the fly by reading the original file and performing operations only as necessary ("lazy" evaluation).  `FluidDump` objects can be sliced similarly to `numpy` arrays, and subsequent file reads and calculations will be done over only the sliced portion.
 
-Finally, as a consequence of needing to read GRMHD output, pyHARM includes definitions of various coordinate systems in Kerr spacetime, as well as tools for dealing with a logically Cartesian grid in various coordinate systems.  These might be independently useful, see `coordinates.py` & `grid.py` if you're looking for just coordinate tools.
+Finally, as a consequence of needing to read GRMHD output, pyharm includes definitions of various coordinate systems in Kerr spacetime, as well as tools for dealing with a logically Cartesian grid in various coordinate systems.  These might be independently useful, see `coordinates.py` & `grid.py` if you're looking for just coordinate tools.
 
 ## Installing:
 The preferred installation method, for flexibility in changing the source as needed, is to run simply:
 ```bash
 $ pip3 install -e .
 ```
-Thereafter pyHARM should be importable from any Python prompt or script run in the same environment.  It can also be installed as a user or system package, but at the cost of less easily modifying the source.
+Thereafter pyharm should be importable from any Python prompt or script run in the same environment.  It can also be installed as a user or system package, but at the cost of less easily modifying the source.
 
 ## Examples:
-Often, what you need to do is covered somewhere in the existing scripts bundled with pyHARM.  Check out the `scripts/` directory.  The two main scripts are `movie.py` for producing plots and movies, and `analysis.py` for performing a set of reductions over a full simulation's output.  If you need to produce a plot, try adapting something from `pyHARM.plots.figures`.  Adding plots to that directory makes them accessible to `movie.py` when you're ready to run at scale.
+Often, what you need to do is covered somewhere in the existing scripts bundled with pyharm.  Check out the `scripts/` directory.  The two main scripts are `movie.py` for producing plots and movies, and `analysis.py` for performing a set of reductions over a full simulation's output.  If you need to produce a plot, try adapting something from `pyharm.plots.figures`.  Adding plots to that directory makes them accessible to `movie.py` when you're ready to run at scale.
 
 For more general usage, the `notebooks` directory has a sample Jupyter notebook playing around with some basic reductions & plots.
 
@@ -60,4 +60,4 @@ Finally, members of the `Grid` object are also accessible through `FluidDump` ob
 
 ## Reductions
 
-See `analysis.py` in scripts and `reductions.py` in pyHARM.
+See `analysis.py` in scripts and `reductions.py` in pyharm.

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -7,7 +7,7 @@
       <img src="{{ pathto("_static/by.png", 1) }}" width=100
            border="0" alt="Creative Commons License"/>
      </a>
-     Documentation for pyHARM is released under a
+     Documentation for pyharm is released under a
      <a href="https://creativecommons.org/licenses/by/4.0/">
        Creative Commons Attribution 4.0 International license.
      </a>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ sys.path.insert(0, os.path.abspath('..'))
 
 # -- Project information -----------------------------------------------------
 
-project = 'pyHARM'
+project = 'pyharm'
 copyright = '2019, Ben Prather, George Wong, Charles Gammie, and the Astrophysical Fluids Group at UIUC'
 author = 'Ben Prather, George Wong, Charles Gammie, and the Astrophysical Fluids Group at UIUC'
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,9 @@
-Welcome to pyHARM's documentation!
+Welcome to pyharm's documentation!
 ==================================
 
-This is the documentation for `pyHARM <https://github.com/AFD-Illinois/pyHARM>`_, a Python package for GRMHD.  It may be incomplete, as pyHARM is still very much in development.
+This is the documentation for `pyharm <https://github.com/AFD-Illinois/pyharm>`_, a Python package for GRMHD.  It may be incomplete, as pyharm is still very much in development.
 
-Specifically, pyHARM is a library for dealing with the output of GRMHD codes implemented in the style of HARM `Gammie et. al. (2003) <https://doi.org/10.1086/374594>`_, written in Python.  It includes tools for working with the output from several GRMHD codes, notably the ``iharm3d`` HDF5 format (see :ref:`ref_dumps`).
+Specifically, pyharm is a library for dealing with the output of GRMHD codes implemented in the style of HARM `Gammie et. al. (2003) <https://doi.org/10.1086/374594>`_, written in Python.  It includes tools for working with the output from several GRMHD codes, notably the ``iharm3d`` HDF5 format (see :ref:`ref_dumps`).
 
 Some example scripts for performing a set of analysis reductions, basic plotting operations, and geometry manipulation and recording can be found in the ``script/`` directory of the repository; they may be more up-to-date than the documentation.
 

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -1,4 +1,4 @@
-Installing pyHARM
+Installing pyharm
 =================
 
 The supported/main method for installation is with the Anaconda Python distribution/package manager.  Just download it from [here](https://www.anaconda.com/distribution/#download-section), make sure that ``conda`` is in your ``PATH`` variable, and run the following:
@@ -6,36 +6,36 @@ The supported/main method for installation is with the Anaconda Python distribut
 ::
 
     $ conda env create -f environment.yml
-    $ conda activate pyHARM
+    $ conda activate pyharm
     $ python3 setup.py develop
 
 The HARM algorithm portion of the code (and eventually, pieces of the analysis) are accelerated with [loopy](https://mathema.tician.de/software/loopy/) and [pyopencl](https://mathema.tician.de/software/pyopencl/), which can take advantage of OpenCL compute devices like graphics cards or specialized CPU libraries.  If you want to use an OpenCL device, copy its ICD file into Anaconda's environment, e.g. for Nvidia on Linux:
 
 ::
 
-    $ cp /etc/OpenCL/vendors/nvidia.icd /path/to/anaconda3/envs/pyHARM/etc/OpenCL/vendors/
+    $ cp /etc/OpenCL/vendors/nvidia.icd /path/to/anaconda3/envs/pyharm/etc/OpenCL/vendors/
 
-pyHARM can then be run or imported by entering the ``conda`` environment:
+pyharm can then be run or imported by entering the ``conda`` environment:
 
 ::
 
-    $ conda activate pyHARM
+    $ conda activate pyharm
     $ python3
-    >> import pyHARM
+    >> import pyharm
 
 or
 
 ::
 
-    $ conda activate pyHARM
-    $ python3 pyHARM/harm.py
+    $ conda activate pyharm
+    $ python3 pyharm/harm.py
 
-In general, ``pyHARM`` should more or less act like an installable ``setuptools`` package -- however, user and system installs are not tested so YMMV.
+In general, ``pyharm`` should more or less act like an installable ``setuptools`` package -- however, user and system installs are not tested so YMMV.
 
 Installing without OpenCL
 =========================
 
-If you just want the analysis tools, and don't care about the OpenCL code, pyHARM can be installed without OpenCL using just the command:
+If you just want the analysis tools, and don't care about the OpenCL code, pyharm can be installed without OpenCL using just the command:
 
 ::
 

--- a/docs/ref_coords.rst
+++ b/docs/ref_coords.rst
@@ -1,4 +1,4 @@
-.. module:: pyHARM
+.. module:: pyharm
 .. moduleauthor:: Ben Prather <bprathr2@illinois.edu>
 
 .. _ref_coords:
@@ -6,20 +6,20 @@
 Coordinate Tools
 ================
 
-pyHARM's tools for dealing with coordinates are split into two files: :mod:`pyHARM.coordinates`, for dealing with continuous transformations between different coordinate systems in the Kerr metric, and :mod:`pyHARM.grid` for holding a Cartesian mesh of native coordinates, coupled with their local metric, connection coefficients, and transformation matrices back to some "base" coordinate system (currently must be Kerr-Schild coordinates)
+pyharm's tools for dealing with coordinates are split into two files: :mod:`pyharm.coordinates`, for dealing with continuous transformations between different coordinate systems in the Kerr metric, and :mod:`pyharm.grid` for holding a Cartesian mesh of native coordinates, coupled with their local metric, connection coefficients, and transformation matrices back to some "base" coordinate system (currently must be Kerr-Schild coordinates)
 
 Coordinate Systems
 ------------------
 
-Coordinate systems are implemented as classes, each of which subclasses :class:`pyHARM.coordinates.CoordinateSystem` and implements the methods it contains:
+Coordinate systems are implemented as classes, each of which subclasses :class:`pyharm.coordinates.CoordinateSystem` and implements the methods it contains:
 
-.. autoclass:: pyHARM.coordinates.CoordinateSystem
+.. autoclass:: pyharm.coordinates.CoordinateSystem
    :members:
 
-The coordinate systems currently supported are Minkowski (:class:`pyHARM.coordinates.Minkowski`), Kerr-Schild (:class:`pyHARM.coordinates.KS`), Modified Kerr-Schild (:class:`pyHARM.coordinates.MKS`), and "Funky" Modified Kerr-Schild (:class:`pyHARM.coordinates.FMKS`).  The ``MKS`` and ``FMKS`` systems are used to concentrate zones toward the midplane, and to make zones near the pole larger, in order to preserve accuracy in simulations while maintaining a reasonable time step (which is driven by the Courant condition at the pole).  Details on these coordinate systems can be found `here <https://github.com/AFD-Illinois/docs/wiki/Coordinates>`_.
+The coordinate systems currently supported are Minkowski (:class:`pyharm.coordinates.Minkowski`), Kerr-Schild (:class:`pyharm.coordinates.KS`), Modified Kerr-Schild (:class:`pyharm.coordinates.MKS`), and "Funky" Modified Kerr-Schild (:class:`pyharm.coordinates.FMKS`).  The ``MKS`` and ``FMKS`` systems are used to concentrate zones toward the midplane, and to make zones near the pole larger, in order to preserve accuracy in simulations while maintaining a reasonable time step (which is driven by the Courant condition at the pole).  Details on these coordinate systems can be found `here <https://github.com/AFD-Illinois/docs/wiki/Coordinates>`_.
 
 The Grid Class
 --------------
 
-.. automodule:: pyHARM.grid
+.. automodule:: pyharm.grid
    :members:

--- a/docs/ref_dumps.rst
+++ b/docs/ref_dumps.rst
@@ -1,4 +1,4 @@
-.. module:: pyHARM
+.. module:: pyharm
 .. moduleauthor:: Ben Prather <bprathr2@illinois.edu>
 
 .. _ref_dumps:
@@ -8,16 +8,16 @@ Reading HARM HDF5 Output
 
 These are functions for reading files of the form documented on the AFD docs `wiki <https://github.com/AFD-Illinois/docs/wiki/Output-Format>`_.  This is the format used by modern iterations of ``iharm3d`` and ``ebhlight``, as well as the HARM implementation in this package.  Several tools for converting output from other codes into this format can be found at `EHT-babel <https://github.com/AFD-Illinois/EHT-babel>`_.
 
-There are two ways to read HARM HDF5 output with the pyHARM tools: the high level interface, :mod:`pyHARM.ana.iharm_dump`, which allows accessing derived variables of several types in a ``dict``-like interface, or :mod:`pyHARM.io`, which reads and writes arrays of the primitive variables used by HARM.
+There are two ways to read HARM HDF5 output with the pyharm tools: the high level interface, :mod:`pyharm.ana.iharm_dump`, which allows accessing derived variables of several types in a ``dict``-like interface, or :mod:`pyharm.io`, which reads and writes arrays of the primitive variables used by HARM.
 
 IharmDump interface
 -------------------
 
-.. automodule:: pyHARM.ana.iharm_dump
+.. automodule:: pyharm.ana.iharm_dump
    :members:
 
 h5io interface
 --------------
 
-.. automodule:: pyHARM.io
+.. automodule:: pyharm.io
    :members:

--- a/docs/ref_plots.rst
+++ b/docs/ref_plots.rst
@@ -1,4 +1,4 @@
-.. module:: pyHARM
+.. module:: pyharm
 .. moduleauthor:: Ben Prather <bprathr2@illinois.edu>
 
 .. _ref_plots:

--- a/docs/variables.rst
+++ b/docs/variables.rst
@@ -1,4 +1,4 @@
-Variable names in pyHARM
+Variable names in pyharm
 ========================
 
 The central mode of interacting with ``FluidDump`` objects is via ``[]``, i.e., Python's ``__getitem__()`` function.  This can be used to request nearly any variable or property of a dump file, so long as one knows under what name it is recorded.

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: pyHARM
+name: pyharm
 
 channels:
  - conda-forge

--- a/notebooks/Sample.ipynb
+++ b/notebooks/Sample.ipynb
@@ -6,13 +6,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# This notebook is intended to demonstrate basic use of pyHARM.  It is a work in progress, additions or issues welcome\n",
-    "# Note this requires pyHARM to be installed via `setup.py develop` or `pip install .`, unless you move it to the root of this repository\n",
+    "# This notebook is intended to demonstrate basic use of pyharm.  It is a work in progress, additions or issues welcome\n",
+    "# Note this requires pyharm to be installed via `setup.py develop` or `pip install .`, unless you move it to the root of this repository\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "import pyHARM\n",
-    "import pyHARM.ana.plot as pplt\n",
+    "import pyharm\n",
+    "import pyharm.ana.plot as pplt\n",
     "\n",
     "# Suppress math warnings. These are just for /0 or sqrt(-)\n",
     "import sys\n",
@@ -27,13 +27,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# The heart of pyHARM is the IharmDump object, which acts like a dictionary of different fluid variables, without storing them in memory as arrays.\n",
+    "# The heart of pyharm is the IharmDump object, which acts like a dictionary of different fluid variables, without storing them in memory as arrays.\n",
     "# By default it just loads the primitive variables over the grid -- however, there are several options to add anything else present in HARM output.\n",
     "# Very likely, you will want to cache the velocity and magnetic field 4-vectors with calc_derived=True\n",
     "# You can also add the conserved variable forms (U vector) with calc_derived=True\n",
     "# If they're present in the original file, you can also load information about the 4-current, floor hits, inversion failures, and B-field divergence -- see the function description of the IharmDump constructor __init__ in 'ana.iharm_dump', for which load_dump is an alias.\n",
     "\n",
-    "dump = pyHARM.load_dump(\"dump_00002000.h5\", calc_derived=True)"
+    "dump = pyharm.load_dump(\"dump_00002000.h5\", calc_derived=True)"
    ]
   },
   {
@@ -48,7 +48,7 @@
     "# or retrieve the variable, do some operations, and pass the resulting ndarray, as below.\n",
     "# A full list of named variables is at the top of 'ana.variables', and reductions like 'shell_sum' are defined in 'ana.reductions'\n",
     "# A limited library of prefixes, indices, etc is also supported; documentation soon, see 'ana.iharm_dump' in the meantime\n",
-    "0.5 * pyHARM.shell_sum(dump, np.fabs(dump['B1']), at_zone=5) / np.sqrt(-pyHARM.shell_sum(dump, 'FM', at_zone=5))"
+    "0.5 * pyharm.shell_sum(dump, np.fabs(dump['B1']), at_zone=5) / np.sqrt(-pyharm.shell_sum(dump, 'FM', at_zone=5))"
    ]
   },
   {
@@ -60,12 +60,12 @@
     "# Check the accretion rate vs radius, summed only in the disk and over the full sphere\n",
     "# The function 'pretty' tries to guess the LaTeX name that represents a variable.\n",
     "# It's necessarily not perfect -- mostly it's useful when writing code meant to plot any available variable, such as 'auto_plot.py' or 'quick_plot.py' in scripts/\n",
-    "plt.plot(dump['r'][:,0,0], -pyHARM.shell_sum(dump, 'FM', th_slice=(5*np.pi/12, 7*np.pi/12)), label=\"Disk\")\n",
-    "plt.plot(dump['r'][:,0,0], -pyHARM.shell_sum(dump, 'FM'), label=\"All\")\n",
+    "plt.plot(dump['r'][:,0,0], -pyharm.shell_sum(dump, 'FM', th_slice=(5*np.pi/12, 7*np.pi/12)), label=\"Disk\")\n",
+    "plt.plot(dump['r'][:,0,0], -pyharm.shell_sum(dump, 'FM'), label=\"All\")\n",
     "plt.xlim(0,50)\n",
     "plt.ylim(0,30)\n",
-    "plt.xlabel(pyHARM.pretty('r'))\n",
-    "plt.ylabel(pyHARM.pretty('Mdot'))\n",
+    "plt.xlabel(pyharm.pretty('r'))\n",
+    "plt.ylabel(pyharm.pretty('Mdot'))\n",
     "plt.title(r\"Shell-summed inward mass flux by radius\")\n",
     "plt.legend()\n",
     "plt.show()"
@@ -78,11 +78,11 @@
    "outputs": [],
    "source": [
     "# The shell-averaged azimuthal velocity as a function of r is usually more stable\n",
-    "plt.plot(dump['r'][:,0,0], pyHARM.shell_avg(dump, 'u^phi'))\n",
+    "plt.plot(dump['r'][:,0,0], pyharm.shell_avg(dump, 'u^phi'))\n",
     "plt.xlim(0,400)\n",
     "plt.yscale('log')\n",
-    "plt.xlabel(pyHARM.pretty('r'))\n",
-    "plt.ylabel(pyHARM.pretty('u^phi'))\n",
+    "plt.xlabel(pyharm.pretty('r'))\n",
+    "plt.ylabel(pyharm.pretty('u^phi'))\n",
     "plt.title(r\"Shell-average u^{\\phi}\")\n",
     "plt.show()"
    ]
@@ -95,7 +95,7 @@
    "source": [
     "# Is pi/3-2pi/3 really representative of the disk?  Let's check how much of the accretion\n",
     "# falls in that range\n",
-    "# Note this uses pyHARM's 2D plotting functions in 'ana.plot'\n",
+    "# Note this uses pyharm's 2D plotting functions in 'ana.plot'\n",
     "fig, ax = plt.subplots(1,1)\n",
     "pplt.plot_xz(ax, dump, np.log10(-dump['FM']), window=[-5,5,-5,5])\n",
     "pplt.overlay_contours(ax, dump, 'th', [np.pi/3, 2*np.pi/3])\n",
@@ -113,7 +113,7 @@
     "# Perhaps the most common is 'log_' which simply avoids having to write np.log10() everywhere\n",
     "# Note this little \"language\" isn't set in stone yet -- in particular:\n",
     "# 1. there may be differences in how plotting vs IharmDump handle 'log_'\n",
-    "# 2. Future reductions may be added in the same way as pdf_, or it may be removed in favor of pyHARM.pdf()\n",
+    "# 2. Future reductions may be added in the same way as pdf_, or it may be removed in favor of pyharm.pdf()\n",
     "# Note that the 'bins' returned represents bin *borders*, as in np.hist -- for this informal plot, we just use the start of each bin\n",
     "d_var, d_var_bins = dump['pdf_log_rho']\n",
     "plt.plot(d_var_bins[:-1], d_var)"
@@ -131,9 +131,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:pyHARM]",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda-env-pyHARM-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -145,7 +145,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.11"
   }
  },
  "nbformat": 4,

--- a/pyharm/__init__.py
+++ b/pyharm/__init__.py
@@ -8,6 +8,6 @@ from .defs import Loci
 
 def load_dump(fname, **kwargs):
     """Wrapper for creating a new IharmDump object from the given file
-    See pyHARM/ana/iharm_dump.py
+    See pyharm/ana/iharm_dump.py
     """
     return FluidDump(fname, **kwargs)

--- a/pyharm/grid.py
+++ b/pyharm/grid.py
@@ -4,8 +4,8 @@ import copy
 from operator import truediv
 import numpy as np
 
-from pyHARM.defs import Loci, Slices, Shapes
-from pyHARM.coordinates import *
+from pyharm.defs import Loci, Slices, Shapes
+from pyharm.coordinates import *
 
 
 def make_some_grid(type, n1=128, n2=128, n3=128, a=0, hslope=0.3, r_in=None, r_out=1000, caches=True, cache_conn=False):

--- a/pyharm/grmhd/b_field.py
+++ b/pyharm/grmhd/b_field.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from pyHARM.defs import Loci, Slices
+from pyharm.defs import Loci, Slices
 
 """Magnetic field tools. Currently just divB"""
 

--- a/pyharm/grmhd/resize.py
+++ b/pyharm/grmhd/resize.py
@@ -2,8 +2,8 @@
 import numpy as np
 from scipy.interpolate import RegularGridInterpolator
 
-from pyHARM.defs import Loci
-from pyHARM.grid import Grid
+from pyharm.defs import Loci
+from pyharm.grid import Grid
 
 def resize(params, G, P, n1, n2, n3, method='linear'):
     """Resize the primitives P onto a new grid.

--- a/pyharm/grmhd/u_to_p.py
+++ b/pyharm/grmhd/u_to_p.py
@@ -4,7 +4,7 @@
 import numpy as np
 import pyopencl.array as cl_array
 
-from pyHARM.defs import Loci
+from pyharm.defs import Loci
 
 
 def U_to_P(params, G, U, P, loc=Loci.CENT, slc=None):

--- a/pyharm/io/__init__.py
+++ b/pyharm/io/__init__.py
@@ -30,7 +30,7 @@ def get_fnames(path):
     raise FileNotFoundError("No dump files found at {}".format(path))
 
 def _get_filter_class(fname):
-    """Internal pyHARM i/o function to choose which class to use when reading a new file.
+    """Internal pyharm i/o function to choose which class to use when reading a new file.
     Ideally should be kept very fast, as sometimes not much is actually *read* from the file
     afterward.
     """

--- a/pyharm/io/gridfile.py
+++ b/pyharm/io/gridfile.py
@@ -3,7 +3,7 @@
 import numpy as np
 import h5py
 
-from pyHARM.defs import Loci
+from pyharm.defs import Loci
 
 # TODO readers for iharm3d-style and ebhlight-style grids to Grid objects
 

--- a/pyharm/io/hamr.py
+++ b/pyharm/io/hamr.py
@@ -70,7 +70,7 @@ class HAMRFile(DumpFile):
 
     def _prep_array(self, arr, astype=None):
         """Re-order and optionally up-convert an array from a file,
-        to put it in usual pyHARM order/format
+        to put it in usual pyharm order/format
         """
         # Ravel
         n1, n2, n3 = self.params['n1'], self.params['n2'], self.params['n3']

--- a/pyharm/io/harm2d.py
+++ b/pyharm/io/harm2d.py
@@ -70,7 +70,7 @@ class HARM2DFile(DumpFile):
     def read_var(self, var, slc=(), **kwargs):
         """Read the header and primitives from an iharm2d v3 ASCII file.
         No analysis or extra processing is performed
-        @return P, params in standard pyHARM
+        @return P, params in standard pyharm
         """
         i = self.index_of(var)
         if i is not None:

--- a/pyharm/io/iharm3d.py
+++ b/pyharm/io/iharm3d.py
@@ -153,9 +153,9 @@ class Iharm3DFile(DumpFile):
 
     def _prep_array(self, arr, astype=None):
         """Re-order and optionally up-convert an array from a file,
-        to put it in usual pyHARM order/format
+        to put it in usual pyharm order/format
         """
-        # Reverse indices on vectors, since most pyHARM tooling expects p,i,j,k
+        # Reverse indices on vectors, since most pyharm tooling expects p,i,j,k
         # See iharm_dump for analysis interface that restores i,j,k,p order
         if len(arr.shape) > 3:
             arr = np.einsum("...m->m...", arr)

--- a/pyharm/io/iharm3d_header.py
+++ b/pyharm/io/iharm3d_header.py
@@ -24,7 +24,7 @@ mks_keys = ['r_eh', 'r_in', 'r_out', 'a', 'hslope']
 mmks_keys = ['poly_alpha', 'poly_xt']
 fmks_keys = ['mks_smooth', 'poly_alpha', 'poly_xt']
 
-# Translations of things the rest of pyHARM tolerates/understands as elements of 'params', but which are not
+# Translations of things the rest of pyharm tolerates/understands as elements of 'params', but which are not
 # conformant for headers and should be written with an alternate name.
 translations = {'n1': 'n1tot', 'n2': 'n2tot', 'n3': 'n3tot',
                 'metric': 'coordinates', 'metric_run': 'coordinates'}
@@ -105,7 +105,7 @@ def read_hdr(grp):
 
     except KeyError as e:
         print("Warning: {}".format(e))
-        print("File is older than supported, but pyHARM will attempt to continue".format(e))
+        print("File is older than supported, but pyharm will attempt to continue".format(e))
 
 
     # Fix up all the nasty non-Unicode strings
@@ -140,9 +140,9 @@ def read_hdr(grp):
         if ('r_in' not in params) and ('Rin' in params):
             params['r_in'], params['r_out'] = params['Rin'], params['Rout']
 
-    # Renames we've done for pyHARM  or are useful
+    # Renames we've done for pyharm  or are useful
     # params_key -> likely name in existing header
-    # header_key -> desired name in conformant/pyHARM header
+    # header_key -> desired name in conformant/pyharm header
     for params_key in translations:
         header_key = translations[params_key]
         if params_key in params:

--- a/pyharm/io/interface.py
+++ b/pyharm/io/interface.py
@@ -1,5 +1,5 @@
 
-"""This interface provides the list of functions to implement for new file filters for pyHARM.
+"""This interface provides the list of functions to implement for new file filters for pyharm.
 A good base set of variables would be to provide something logical for the strings RHO:B3 in both
 lists below.  The provided index_of() function returns the expected indices 1-8 for these variables --
 if your file has an array prims[] you can likely return prims[:,:,:,index_of(var)] and cover many/most calls.

--- a/pyharm/io/koral.py
+++ b/pyharm/io/koral.py
@@ -51,7 +51,7 @@ class KORALFile(DumpFile):
 
     def _prep_array(arr, as_double=False, zones_first=False, add_ghosts=False):
         """Re-order and optionally up-convert an array from a file,
-        to put it in usual pyHARM order/format
+        to put it in usual pyharm order/format
         """
         # Upconvert to doubles if necessary
         # TODO could add other types?  Not really necessary yet

--- a/pyharm/plots/frame.py
+++ b/pyharm/plots/frame.py
@@ -17,7 +17,7 @@ from .pretty import pretty
 
 
 """Generate one frame of a movie.  Currently pretty useless outside `movie.py`,
-present in pyHARM so as to be importable by different MPI processes and across movie generation "schemes," if it comes to that.
+present in pyharm so as to be importable by different MPI processes and across movie generation "schemes," if it comes to that.
 """
 
 def frame(fname, diag, kwargs):

--- a/pyharm/plots/plot_utils.py
+++ b/pyharm/plots/plot_utils.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 from matplotlib import colors, ticker
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-"""Generic utilities and plot types -- anything potentially useful/stolen from outside pyHARM
+"""Generic utilities and plot types -- anything potentially useful/stolen from outside pyharm
 """
 
 def pcolormesh_symlog(ax, X, Y, Z, vmax=None, vmin=None, linthresh=None, decades=4, linscale=0.01, cmap='RdBu_r', cbar=True, **kwargs):

--- a/pyharm/plots/pretty.py
+++ b/pyharm/plots/pretty.py
@@ -1,5 +1,5 @@
 
-"""This file provides a function 'pretty' which takes a variable name used in pyHARM,
+"""This file provides a function 'pretty' which takes a variable name used in pyharm,
 and returns the LaTeX form of the name, suitable for plot axes.
 """
 

--- a/pyharm/reductions.py
+++ b/pyharm/reductions.py
@@ -2,7 +2,7 @@ import numpy as np
 import scipy.fftpack as fft
 
 # This is too darn useful
-from pyHARM.util import i_of
+from pyharm.util import i_of
 
 """
 General interface for reductions:

--- a/scripts/analysis.py
+++ b/scripts/analysis.py
@@ -30,17 +30,17 @@ if not sys.warnoptions:
 # For memory usage stats
 import psutil
 
-import pyHARM
-# Spam base namespace so we don't have to type pyHARM or even ph
-from pyHARM.variables import *
-from pyHARM.reductions import *
+import pyharm
+# Spam base namespace so we don't have to type pyharm or even ph
+from pyharm.variables import *
+from pyharm.reductions import *
 
-import pyHARM.io as io
-import pyHARM.util as util
+import pyharm.io as io
+import pyharm.util as util
 
 # Specific useful things 
-from pyHARM.defs import Loci
-from pyHARM.util import i_of
+from pyharm.defs import Loci
+from pyharm.util import i_of
 
 # Whether to augment or replace existing results
 # Augmenting behaves *very* badly when jobs time out or are cancelled
@@ -119,7 +119,7 @@ if tend == 0.:
     tend = float(ND)
 
 # Get header and geometry stuff from the first dump on the list
-dump = pyHARM.load_dump(dumps[0], params=params, calc_derived=False)
+dump = pyharm.load_dump(dumps[0], params=params, calc_derived=False)
 hdr = dump.header
 
 if dump['r'].ndim == 3:
@@ -177,7 +177,7 @@ def avg_dump(n):
 
     print("Loading {} / {}: t = {}".format((n + 1), len(dumps), int(t)), file=sys.stderr)
     # TODO Add only what we need here...
-    dump = pyHARM.load_dump(dumps[n], params=params, calc_derived=True, add_jcon=False, add_fails=False, add_floors=False)
+    dump = pyharm.load_dump(dumps[n], params=params, calc_derived=True, add_jcon=False, add_fails=False, add_floors=False)
 
     # Should we compute the time-averaged quantities?
     do_tavgs = (tavg_start <= t <= tavg_end)

--- a/scripts/batch/movie_andes.sb
+++ b/scripts/batch/movie_andes.sb
@@ -1,6 +1,6 @@
 #!/bin/bash -i
 
-#SBATCH -J pyHARM_movie
+#SBATCH -J pyharm_movie
 #SBATCH -A ast171
 #SBATCH -N 1
 #SBATCH --ntasks-per-node 32
@@ -22,7 +22,7 @@
 # Sourcing the conda script doesn't seem to fully work anymore,
 # so we run as interactive with '-i' above, which is not ideal
 #source /sw/andes/python/3.7/anaconda-base/etc/profile.d/conda.sh
-conda activate pyHARM
+conda activate pyharm
 
 # Better to oversubscribe CPU than serialize as there are
 # relatively few numpy ops
@@ -32,4 +32,4 @@ export OMP_NUM_THREADS=8
 # The intent of the directives is to start 32 tasks per node (or more?),
 # but not *bind* them to particular cores --
 # we want to allow MKL_NTHREADS and OMP_NTHREADS to work
-srun ~/Code/pyHARM/scripts/movie.py "${@}"
+srun ~/Code/pyharm/scripts/movie.py "${@}"

--- a/scripts/batch/movie_frontera.sb
+++ b/scripts/batch/movie_frontera.sb
@@ -3,10 +3,10 @@
 # This can be used as either a submit script or a bash script from a dev job (bash movie.sb [etc])
 # Usage:
 # sbatch movie.sb type [arguments] -- path1 path2 path3
-# Where type is documented in pyHARM/scripts/movie.py
+# Where type is documented in pyharm/scripts/movie.py
 
 # Frontera sbatch directives
-#SBATCH -J pyHARM_movie
+#SBATCH -J pyharm_movie
 #SBATCH -p development
 #SBATCH -N 1
 #SBATCH --ntasks-per-node 56
@@ -16,7 +16,7 @@
 # Make sure we *do* use Frontera's python, now we don't need OpenCL
 # Intel MPI and mpi4py do *not* mix, load mvapich instead. Speed is secondary.
 module load python3 mvapich2-x
-PYHARM_DIR="$HOME/Code/pyHARM/scripts"
+PYHARM_DIR="$HOME/Code/pyharm/scripts"
 
 # Just in case we're running from bash
 export IBRUN_NPROCS=56

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -5,13 +5,13 @@ import psutil
 import click
 import multiprocessing
 
-import pyHARM
+import pyharm
 
 def convert_file(fname, outfname):
     """Read a single file of some type, and write it as Illinois HDF5 format"""
-    dump = pyHARM.load_dump(fname, grid_cache=False)
+    dump = pyharm.load_dump(fname, grid_cache=False)
     # The zero is dt, which KHARMA does not keep
-    pyHARM.io.iharm3d.write_dump(dump, outfname)
+    pyharm.io.iharm3d.write_dump(dump, outfname)
 
 @click.command()
 @click.argument('files', nargs=-1)
@@ -22,10 +22,10 @@ def convert_file(fname, outfname):
 @click.option('-d', '--debug', is_flag=True, help="Serial operation for debugging")
 def convert(files, path, outfile, nthreads, debug):
     """Convert a file from KHARMA format (or any readable format) into iharm3d/Illinois HDF5 format
-    (and only this format, as pyHARM cannot write other file formats).
+    (and only this format, as pyharm cannot write other file formats).
 
     Tries to preserve as much as possible of the original data, but not everything may transfer:
-    see pyHARM/io/iharm3d.py for details of the file writer.
+    see pyharm/io/iharm3d.py for details of the file writer.
 
     Defaults to writing output to the same directory as input files, optionally output to a different
     directory with '-p'. Adds a '.h5' file extension in place of KHARMA's .phdf, or additionally to other

--- a/scripts/movie.py
+++ b/scripts/movie.py
@@ -28,9 +28,9 @@ except ImportError:
     def do_out():
         return True
 
-import pyHARM
-from pyHARM.plots.frame import frame
-from pyHARM.util import calc_nthreads
+import pyharm
+from pyharm.plots.frame import frame
+from pyharm.util import calc_nthreads
 
 @click.command()
 @click.argument('movie_type', nargs=1)
@@ -56,14 +56,14 @@ from pyHARM.util import calc_nthreads
 def movie(movie_type, paths, **kwargs):
     """Movie of type MOVIE_TYPE from dumps at each of PATHS.
 
-    Each PATH can contain dump files in any format readable by pyHARM, either in the given directory or a subdirectory
+    Each PATH can contain dump files in any format readable by pyharm, either in the given directory or a subdirectory
     named "dumps", "dumps_kharma" or similar.
 
     "Movies" are generated as collections of frames in .png format, named frame_tXXXXXXXX.png by simulation time in M,
     and placed in a subdirectory "frames_MOVIE_TYPE" of the given PATH.  One can easily generate a single .mp4 movie
     from these using ffmpeg or similar.
 
-    MOVIE_TYPE can be any variable known to pyHARM (see README, variables.py) or any "figure" function in figures.py.  A common
+    MOVIE_TYPE can be any variable known to pyharm (see README, variables.py) or any "figure" function in figures.py.  A common
     first movie is 'log_rho' which will plot a phi=0 toroidal and midplane poloidal slice of the log_10 of the density. 
 
     If run within an MPI job/allocation with mpi4py installed, movie.py will attempt to use all allocated nodes to generate
@@ -81,7 +81,7 @@ def movie(movie_type, paths, **kwargs):
             # change dir to path we want to image
             os.chdir(path)
             # Try to load known filenames
-            files = pyHARM.io.get_fnames(".")
+            files = pyharm.io.get_fnames(".")
         else:
             files = [path]
 
@@ -96,7 +96,7 @@ def movie(movie_type, paths, **kwargs):
             # Load diagnostics from HARM itself
             fname = glob.glob("*.hst")[0]
             if do_out(): print("Loading diag file {}".format(fname), file=sys.stderr)
-            diag = pyHARM.io.read_log(fname)
+            diag = pyharm.io.read_log(fname)
         except IOError:
             diag = None
 
@@ -124,7 +124,7 @@ def movie(movie_type, paths, **kwargs):
             # Try to guess how many processes before we MemoryError out
             if 'nthreads' not in kwargs or kwargs['nthreads'] is None:
                 if 'memory_limit' in kwargs and kwargs['memory_limit'] is not None:
-                    hdr = pyHARM.io.read_hdr(files[0])
+                    hdr = pyharm.io.read_hdr(files[0])
                     nthreads = min(calc_nthreads(hdr, pad=0.6),
                                 psutil.cpu_count())
                 else:

--- a/scripts/old/auto_plot.py
+++ b/scripts/old/auto_plot.py
@@ -7,8 +7,8 @@ import h5py
 import matplotlib.pyplot as plt
 import matplotlib.colors as colors
 
-from pyHARM.plots.plot_dumps import pcolormesh_symlog
-from pyHARM.ana_results import AnaResults
+from pyharm.plots.plot_dumps import pcolormesh_symlog
+from pyharm.ana_results import AnaResults
 
 infname = sys.argv[1]
 

--- a/scripts/old/compare.py
+++ b/scripts/old/compare.py
@@ -6,8 +6,8 @@
 #                                                                              #
 ################################################################################
 
-import pyHARM
-import pyHARM.plots.plot_dumps as pplt
+import pyharm
+import pyharm.plots.plot_dumps as pplt
 
 import sys
 import numpy as np
@@ -28,9 +28,9 @@ dump1file = sys.argv[1]
 dump2file = sys.argv[2]
 imname = sys.argv[3]
 
-dump1 = pyHARM.load_dump(dump1file, grid_cache=False)
+dump1 = pyharm.load_dump(dump1file, grid_cache=False)
 #Hopefully this fails for dumps that shouldn't be compared
-dump2 = pyHARM.load_dump(dump2file, grid_cache=False)
+dump2 = pyharm.load_dump(dump2file, grid_cache=False)
 
 log_floor = -8
 

--- a/scripts/old/compareflux.py
+++ b/scripts/old/compareflux.py
@@ -7,8 +7,8 @@ import numpy as np
 from numpy.polynomial.polynomial import Polynomial
 import matplotlib.pyplot as plt
 
-from pyHARM.ana_results import *
-from pyHARM.reductions import pspec
+from pyharm.ana_results import *
+from pyharm.reductions import pspec
 
 ivar = sys.argv[1]
 var = sys.argv[2]

--- a/scripts/old/compareprofiles.py
+++ b/scripts/old/compareprofiles.py
@@ -5,8 +5,8 @@ import h5py
 
 import matplotlib.pyplot as plt
 
-from pyHARM.ana_results import *
-from pyHARM.util import i_of
+from pyharm.ana_results import *
+from pyharm.util import i_of
 
 x = 5
 var = sys.argv[1]

--- a/scripts/old/compareradial.py
+++ b/scripts/old/compareradial.py
@@ -5,8 +5,8 @@ import h5py
 
 import matplotlib.pyplot as plt
 
-from pyHARM.ana_results import *
-from pyHARM.util import i_of
+from pyharm.ana_results import *
+from pyharm.util import i_of
 
 ivar = sys.argv[1]
 var = sys.argv[2]

--- a/scripts/old/comparetotal.py
+++ b/scripts/old/comparetotal.py
@@ -5,7 +5,7 @@ import h5py
 
 import matplotlib.pyplot as plt
 
-from pyHARM.ana_results import *
+from pyharm.ana_results import *
 
 var = sys.argv[1]
 ivar = sys.argv[2]

--- a/scripts/old/comparison_movie.py
+++ b/scripts/old/comparison_movie.py
@@ -4,7 +4,7 @@
 # Usage: movie.py [type] [/path/to/dumpfiles]
 
 # Where [type] is a string passed to the function below representing what plotting to do in each frame,
-# and [/path/to/dumpfiles] is the path to the *folder* containing HDF5 output in any form which pyHARM can read
+# and [/path/to/dumpfiles] is the path to the *folder* containing HDF5 output in any form which pyharm can read
 
 # Generally good overview movies are 'simplest' & 'traditional', see the function body for details.
 
@@ -19,13 +19,13 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 
-import pyHARM
-import pyHARM.io as io
-from pyHARM.ana.reductions import *
-import pyHARM.ana.plot as pplt
-import pyHARM.ana.plot_results as ppltr
-from pyHARM.ana.variables import T_mixed, pretty
-from pyHARM.util import i_of, calc_nthreads, run_parallel
+import pyharm
+import pyharm.io as io
+from pyharm.ana.reductions import *
+import pyharm.ana.plot as pplt
+import pyharm.ana.plot_results as ppltr
+from pyharm.ana.variables import T_mixed, pretty
+from pyharm.util import i_of, calc_nthreads, run_parallel
 
 # Movie size in inches. Keep 16/9 for standard-size movies
 FIGX = 16
@@ -81,7 +81,7 @@ def plot(n):
 
     dumps = []
     for i in range(len(files)):
-        dumps.append(pyHARM.load_dump(files[i][n], **to_load))
+        dumps.append(pyharm.load_dump(files[i][n], **to_load))
 
     # Title by time, otherwise number
     try:

--- a/scripts/old/how_many_cycles.py
+++ b/scripts/old/how_many_cycles.py
@@ -5,7 +5,7 @@
 
 import sys
 import numpy as np
-import pyHARM.grid as grid
+import pyharm.grid as grid
 
 n1 = int(sys.argv[1])
 n2 = int(sys.argv[2])

--- a/scripts/old/how_many_cycles_xsede.py
+++ b/scripts/old/how_many_cycles_xsede.py
@@ -5,7 +5,7 @@
 
 import sys
 import numpy as np
-import pyHARM.grid as grid
+import pyharm.grid as grid
 
 n1 = int(sys.argv[1])
 n2 = int(sys.argv[2])

--- a/scripts/old/resultmovie.py
+++ b/scripts/old/resultmovie.py
@@ -8,8 +8,8 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
-from pyHARM.ana_results import *
-from pyHARM.util import run_parallel
+from pyharm.ana_results import *
+from pyharm.util import run_parallel
 
 n_avg = 10
 

--- a/scripts/old/write_some_dump.py
+++ b/scripts/old/write_some_dump.py
@@ -4,9 +4,9 @@
 # TODO WIP to write anything more than trivial zeros, needs BL->KS velocities and sensible starting config
 
 import numpy as np
-from pyHARM import grid, units, coordinates
-import pyHARM.io.iharm3d as h5io
-from pyHARM.grmhd.init_tools import fourvel_to_prim, set_fourvel_t
+from pyharm import grid, units, coordinates
+import pyharm.io.iharm3d as h5io
+from pyharm.grmhd.init_tools import fourvel_to_prim, set_fourvel_t
 
 # Problem-specific parameters
 Ne_unit = 3.e-18

--- a/scripts/old/write_trace_bl.py
+++ b/scripts/old/write_trace_bl.py
@@ -4,9 +4,6 @@ import sys
 import h5py
 import numpy as np
 
-import pyHARM
-
-
 trace = h5py.File(sys.argv[1], "r")
 outf = h5py.File(sys.argv[2], "w")
 

--- a/scripts/old/write_vecs_bl.py
+++ b/scripts/old/write_vecs_bl.py
@@ -4,10 +4,10 @@ import sys
 import h5py
 import numpy as np
 
-import pyHARM
+import pyharm
 
 
-dump = pyHARM.load_dump(sys.argv[1])
+dump = pyharm.load_dump(sys.argv[1])
 
 outf = h5py.File(sys.argv[2], "w")
 
@@ -23,8 +23,8 @@ outf['th'] = th
 outf['phi'] = dump.grid.coords.phi(X) - dump['a'] / (r**2 - 2.*r + dump['a']**2) * r
 
 # 4-vectors
-bl = pyHARM.coordinates.BL({'a': dump['a']})
-#ks = pyHARM.coordinates.KS({'a': dump['a']})
+bl = pyharm.coordinates.BL({'a': dump['a']})
+#ks = pyharm.coordinates.KS({'a': dump['a']})
 zero = np.zeros_like(r)
 # Transform native->KS,
 #gcov_ks = ks.gcov(np.array([zero,r,th,zero]))

--- a/scripts/quick_plot.py
+++ b/scripts/quick_plot.py
@@ -10,10 +10,10 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
-import pyHARM
-import pyHARM.plots.plot_dumps as pplt
-from pyHARM import pretty
-from pyHARM.units import get_units_M87
+import pyharm
+import pyharm.plots.plot_dumps as pplt
+from pyharm import pretty
+from pyharm.units import get_units_M87
 
 FIGX = 10
 FIGY = 10
@@ -47,7 +47,7 @@ if len(sys.argv) > 4:
 else:
     unit = 1
 
-dump = pyHARM.load_dump(dumpfile)
+dump = pyharm.load_dump(dumpfile)
 
 if dump['n3'] > 1:
     fig = plt.figure(figsize=(FIGX, FIGY))

--- a/scripts/resize_dump.py
+++ b/scripts/resize_dump.py
@@ -4,11 +4,11 @@
 import sys
 import numpy as np
 
-import pyHARM
-from pyHARM.grmhd.resize import resize
-from pyHARM.io.iharm3d import write_dump
+import pyharm
+from pyharm.grmhd.resize import resize
+from pyharm.io.iharm3d import write_dump
 
-dump = pyHARM.load_dump(sys.argv[1], calc_derived=False, add_ghosts=True)
+dump = pyharm.load_dump(sys.argv[1], calc_derived=False, add_ghosts=True)
 
 # TODO just return IharmDump object?
 params_new, Gnew, Pnew = resize(dump.params, dump.grid, dump.prims, dump['n1']*2, dump['n2']*2, dump['n3']*2)

--- a/scripts/write_grid.py
+++ b/scripts/write_grid.py
@@ -3,10 +3,10 @@
 import click
 import numpy as np
 import h5py
-from pyHARM.defs import Loci
-from pyHARM import grid
-from pyHARM.grid import Grid
-from pyHARM import io
+from pyharm.defs import Loci
+from pyharm import grid
+from pyharm.grid import Grid
+from pyharm import io
 
 def write_bhlight_grid(G, outfname):
     """Write a Grid object G to a bhlight-format grid file.

--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,10 @@ def write_git_revision(package_name):
         outf.write("GIT_REVISION = %s\n" % repr(git_rev))
 
 
-write_git_revision("pyHARM")
+write_git_revision("pyharm")
 
 
-setup(name="pyHARM",
+setup(name="pyharm",
       version="2022.2",
       description="Python tools for HARM analysis",
       long_description=open("README.md", "rt").read(),


### PR DESCRIPTION
nothing crazy here, just changing all instances of the mixed-case pyHARM to all-lower-case pyharm.