### PR TITLE
Add features to plot simulations in the comoving frame

### DIFF
--- a/pyharm/ana/reductions.py
+++ b/pyharm/ana/reductions.py
@@ -76,6 +76,8 @@ def flatten_xz(dump, var, at=None, sum=False, half_cut=False):
     else:
         if at is None:
             at = 0
+        else:
+            at = at % dump['n3']
         if isinstance(var, str):
             if half_cut:
                 return np.squeeze(dump[:, :, at][var])

--- a/pyharm/ana/reductions.py
+++ b/pyharm/ana/reductions.py
@@ -80,7 +80,8 @@ def flatten_xz(dump, var, at=None, sum=False, half_cut=False):
             if half_cut:
                 return np.squeeze(dump[:, :, at][var])
             else:
-                return np.append(np.squeeze(dump[:, :, at][var]), np.flip(np.squeeze(dump[:, :, at + dump['n3']//2][var]), 1), 1)
+                ta = (at + dump['n3']//2) % dump['n3']
+                return np.append(np.squeeze(dump[:, :, at][var]), np.flip(np.squeeze(dump[:, :, ta][var]), 1), 1)
         else:
             if half_cut:
                 if len(var.shape) == 3:
@@ -88,7 +89,8 @@ def flatten_xz(dump, var, at=None, sum=False, half_cut=False):
                 else:
                     return var
             else:
-                return np.append(var[:, :, at], np.flip(var[:, :, at + dump['n3']//2], 1), 1)
+                ta = (at + dump['n3']//2) % dump['n3']
+                return np.append(var[:, :, at], np.flip(var[:, :, ta], 1), 1)
 
 def flatten_xy(dump, var, at=None, sum=False):
     """Return an X-Y slice or sum of var.  Note sums are *not* GR-aware!

--- a/pyharm/fluid_state.py
+++ b/pyharm/fluid_state.py
@@ -322,11 +322,8 @@ class FluidState:
         if self.fname != "memory_array":
             # Read things that we haven't cached and absolutely can't calculate
             # The reader keeps its own cache, so we don't add its items to ours
-            if "flag" in key:
-                out = self.reader.read_var(key, astype=np.int32, slc=self.slice)
-            else:
-                # TODO Option for double
-                out = self.reader.read_var(key, astype=np.float64, slc=self.slice)
+            astype = np.int32 if "flag" in key else np.float64
+            out = self.reader.read_var(key, astype=astype, slc=self.slice)
             if out is not None:
                 return out
 

--- a/pyharm/plots/plot_dumps.py
+++ b/pyharm/plots/plot_dumps.py
@@ -197,7 +197,7 @@ def plot_xz(ax, dump, var, vmin=None, vmax=None, window=(-40, 40, -40, 40),
 def plot_xy(ax, dump, var, vmin=None, vmax=None, window=None,
             xlabel=True, ylabel=True, native=False, log=False,
             cmap='jet', shading='gouraud',
-            at=None, average=False, sum=False, cbar=True, log_r=False, **kwargs):
+            at=None, cw=None, average=False, sum=False, cbar=True, log_r=False, **kwargs):
     """Plot a toroidal or X1/X3 slice of a dump file.
     Note this function also accepts all keyword arguments to _decorate_plot()
 
@@ -227,6 +227,8 @@ def plot_xy(ax, dump, var, vmin=None, vmax=None, window=None,
 
     x, y = dump.grid.get_xy_locations(mesh=(shading == 'flat'), native=native, log_r=log_r)
     var = flatten_xy(dump, var, at, sum or average)
+    if cw is not None:
+        var = np.roll(var, -cw, axis=-1)
     if average:
         var /= dump['n2']
     if shading != 'flat':

--- a/pyharm/variables.py
+++ b/pyharm/variables.py
@@ -91,6 +91,7 @@ fns_dict = {# 4-vectors
             'Gamma': lambda dump: lorentz_calc(dump),
             'cs': lambda dump: np.sqrt(dump['gam'] * dump['Pg'] / (dump['RHO'] + dump['gam'] * dump['UU'])),
             'vA': lambda dump: alfven_speed(dump),
+            'vr': lambda dump: dump["u^r"] / dump["u^t"],
             'Omega': lambda dump: dump["u^phi"] / dump["u^t"] ,
             # TODO magnetosonic, EMHD speed, effective timestep
             # Fluxes in radial direction: Mass, Energy, Angular Momentum


### PR DESCRIPTION
Add the `cw` keyworded argument to `plolt_xy()` to rotate the image clockwisely.  Make the `at` argument more robust.  These improvements make plotting simulations in the comoving frame easier.