### PR TITLE
added definitions for sigma_hot and sigma_cold

### DIFF
--- a/pyharm/variables.py
+++ b/pyharm/variables.py
@@ -83,6 +83,8 @@ fns_dict = {# 4-vectors
             'Ptot': lambda dump: dump['Pg'] + dump['Pb'],
             'beta': lambda dump: dump['Pg'] / dump['Pb'],
             'sigma': lambda dump: dump['bsq'] / dump['RHO'],
+            'sigma_cold': lambda dump: dump['bsq'] / dump['RHO'],
+            'sigma_hot': lambda dump: dump['bsq'] / (dump['RHO'] + dump['gam'] * dump['UU']),
             'Theta': lambda dump: (dump['gam'] - 1) * dump['UU'] / dump['RHO'],
             # entropy
             'K': lambda dump: (dump['gam']-1.) * dump['UU'] * pow(dump['RHO'], -dump['gam']),


### PR DESCRIPTION
sigma_cold is an alias for sigma, and equals B^2/rho

sigma_hot is now defined in the code as B^2 / (rho + (gamma * UU)), which should be equivalent to B^2 / (rho + (gamma/(p*(gamma -1))))